### PR TITLE
refactor: centralize window helpers

### DIFF
--- a/apps/mediaplayer.js
+++ b/apps/mediaplayer.js
@@ -1,3 +1,5 @@
+import { createWindow } from '../js/main.js';
+
 // Register the Media Player app
 kernel.registerApp('mediaplayer', 'Media Player', function () {
     return createMediaPlayer();
@@ -6,6 +8,7 @@ kernel.registerApp('mediaplayer', 'Media Player', function () {
 function createMediaPlayer() {
     // Create window
     const w = createWindow("Media Player");
+    w.id = 'mediaplayer:' + Math.random().toString(36).substr(2, 5);
 
     w.element.style.resize = 'none'; // Disable resizing
     w.element.style.overflow = 'hidden'; // Prevent showing resize handles
@@ -62,82 +65,5 @@ function createMediaPlayer() {
     w.content.appendChild(container);
 
     // Return the window object
-    const id = 'mediaplayer:' + Math.random().toString(36).substr(2, 5);
-    return { id, element: w.element };
-}
-
-// Create a window with title and content
-function createWindow(title) {
-    const windowElement = document.createElement('div');
-    windowElement.className = 'window';
-    windowElement.style.position = 'absolute';
-    windowElement.style.background = 'rgba(34, 34, 34, 0.8)';
-    windowElement.style.border = '1px solid rgba(68, 68, 68, 0.5)';
-    windowElement.style.width = '400px';
-    windowElement.style.height = '300px';
-    windowElement.style.resize = 'both';
-    windowElement.style.overflow = 'hidden';
-    windowElement.style.borderRadius = '10px';
-    windowElement.style.backdropFilter = 'blur(15px)';
-    windowElement.style.boxShadow = '0 4px 10px rgba(0, 0, 0, 0.5)';
-    windowElement.style.display = 'flex';
-    windowElement.style.flexDirection = 'column';
-
-    // Title bar
-    const titleBar = document.createElement('div');
-    titleBar.className = 'title-bar';
-    titleBar.style.height = '30px';
-    titleBar.style.background = 'rgba(51, 51, 51, 0.9)';
-    titleBar.style.color = 'white';
-    titleBar.style.display = 'flex';
-    titleBar.style.alignItems = 'center';
-    titleBar.style.padding = '0 5px';
-    titleBar.style.boxSizing = 'border-box';
-    titleBar.style.cursor = 'move';
-    titleBar.style.gap = '10px'; // Adds spacing between elements
-
-    const titleText = document.createElement('div');
-    titleText.className = 'title-text';
-    titleText.textContent = title;
-    titleText.style.flex = 'none';
-
-    const windowButtons = document.createElement('div');
-    windowButtons.className = 'window-buttons';
-    windowButtons.style.display = 'flex';
-    windowButtons.style.alignItems = 'center';
-    windowButtons.style.justifyContent = 'flex-end';
-
-    const closeButton = document.createElement('button');
-    closeButton.textContent = '✖';
-    closeButton.style.background = 'none';
-    closeButton.style.color = 'white';
-    closeButton.style.border = 'none';
-    closeButton.style.cursor = 'pointer';
-    closeButton.style.width = '24px';
-    closeButton.style.height = '24px';
-    closeButton.addEventListener('click', () => {
-        windowElement.remove();
-    });
-    windowButtons.appendChild(closeButton);
-
-    // Append title bar elements
-    titleBar.appendChild(titleText);
-    titleBar.appendChild(windowButtons);
-
-    // Content area
-    const content = document.createElement('div');
-    content.className = 'window-content';
-    content.style.flex = '1';
-    content.style.padding = '5px';
-    content.style.overflow = 'auto';
-    content.style.boxSizing = 'border-box';
-
-    // Append title bar and content to the window
-    windowElement.appendChild(titleBar);
-    windowElement.appendChild(content);
-
-    // Append the window to the document body
-    document.body.appendChild(windowElement);
-
-    return { element: windowElement, content };
+    return w;
 }

--- a/apps/taskmanager.js
+++ b/apps/taskmanager.js
@@ -1,14 +1,15 @@
+import { createWindow, closeAppByElement } from '../js/main.js';
+
 // Register the Task Manager application
 kernel.registerApp('taskmanager', 'Task Manager', function () {
   return createTaskManagerWindow();
 });
 
-  w.element.style.resize = 'none'; // Disable resizing
-  w.element.style.overflow = 'hidden'; // Prevent showing resize handles
-
 // Create Task Manager Window
 function createTaskManagerWindow() {
   const w = createWindow("Task Manager");
+  w.element.style.resize = 'none';
+  w.element.style.overflow = 'hidden';
 
   // Create the list to display running apps
   const list = document.createElement('ul');
@@ -100,61 +101,4 @@ function createTaskManagerWindow() {
   taskManagerWindowObj.startChecking();
 
   return taskManagerWindowObj;
-}
-
-// Close an app by removing its element and reference
-function closeAppByElement(element) {
-  // Remove the app's DOM element
-  element.remove();
-
-  // Remove the app from the apps array
-  window.apps = window.apps.filter((app) => app.element !== element);
-}
-
-// Example `createWindow` function to create app windows
-function createWindow(title) {
-  const windowElement = document.createElement('div');
-  windowElement.className = 'window';
-  windowElement.style.position = 'absolute';
-  windowElement.style.width = '400px';
-  windowElement.style.height = '300px';
-  windowElement.style.border = '1px solid #666';
-  windowElement.style.backgroundColor = '#222';
-  windowElement.style.color = '#fff';
-  windowElement.style.borderRadius = '10px';
-  windowElement.style.padding = '10px';
-  windowElement.style.overflow = 'hidden';
-
-  const titleBar = document.createElement('div');
-  titleBar.className = 'title-bar';
-  titleBar.style.backgroundColor = '#333';
-  titleBar.style.padding = '5px';
-  titleBar.style.cursor = 'move';
-  titleBar.textContent = title;
-
-  const content = document.createElement('div');
-  content.className = 'window-content';
-  content.style.flex = '1';
-  content.style.padding = '5px';
-  content.style.overflow = 'auto';
-
-  windowElement.appendChild(titleBar);
-  windowElement.appendChild(content);
-  document.body.appendChild(windowElement);
-
-  // Make the window draggable
-  titleBar.onmousedown = (e) => {
-      const shiftX = e.clientX - windowElement.getBoundingClientRect().left;
-      const shiftY = e.clientY - windowElement.getBoundingClientRect().top;
-      document.onmousemove = (event) => {
-          windowElement.style.left = `${event.pageX - shiftX}px`;
-          windowElement.style.top = `${event.pageY - shiftY}px`;
-      };
-      document.onmouseup = () => {
-          document.onmousemove = null;
-          document.onmouseup = null;
-      };
-  };
-
-  return { element: windowElement, content };
 }

--- a/index.html
+++ b/index.html
@@ -31,13 +31,13 @@
 <script src="apps/fileexplorer.js"></script>
 <script src="apps/wallpaper.js"></script>
 <script src="apps/devenv.js"></script>
-<script src="apps/taskmanager.js"></script>
-<script src="apps/mediaplayer.js"></script>
+<script type="module" src="apps/taskmanager.js"></script>
+<script type="module" src="apps/mediaplayer.js"></script>
 <script src="apps/about.js"></script>
 <script src="apps/texteditor.js"></script>
 <script src="apps/calculator.js"></script>
 <script src="apps/images.js"></script>
-<script src="js/main.js"></script>
+<script type="module" src="js/main.js"></script>
 
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -87,7 +87,7 @@ function updateClock() {
   clockLabel.textContent=new Date().toLocaleTimeString();
 }
 
-function createWindow(title) {
+export function createWindow(title) {
   let w = document.createElement('div');
   w.className='window';
   w.style.top='100px';
@@ -159,8 +159,12 @@ function createWindow(title) {
   return {id:title.toLowerCase()+':'+Math.random().toString(36).substr(2,5), element:w, content:content};
 }
 
-function closeAppByElement(el) {
+export function closeAppByElement(el) {
   window.apps=window.apps.filter(a=>a.element!==el);
   document.body.removeChild(el);
   updateTaskbar();
 }
+
+// Expose helpers globally for non-module scripts
+window.createWindow = createWindow;
+window.closeAppByElement = closeAppByElement;


### PR DESCRIPTION
## Summary
- export createWindow and closeAppByElement from main.js and expose globally
- reuse shared window helpers in Task Manager and Media Player apps
- load Task Manager, Media Player, and main scripts as ES modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895fd71a4a48332a573829ba7b59216