### PR TITLE
Move window style setup into creation functions

### DIFF
--- a/apps/taskmanager.js
+++ b/apps/taskmanager.js
@@ -3,12 +3,11 @@ kernel.registerApp('taskmanager', 'Task Manager', function () {
   return createTaskManagerWindow();
 });
 
-  w.element.style.resize = 'none'; // Disable resizing
-  w.element.style.overflow = 'hidden'; // Prevent showing resize handles
-
 // Create Task Manager Window
 function createTaskManagerWindow() {
   const w = createWindow("Task Manager");
+  w.element.style.resize = 'none'; // Disable resizing
+  w.element.style.overflow = 'hidden'; // Prevent showing resize handles
 
   // Create the list to display running apps
   const list = document.createElement('ul');

--- a/apps/wallpaper.js
+++ b/apps/wallpaper.js
@@ -1,12 +1,11 @@
 kernel.registerApp('wallpaper','Wallpaper', function() {
     return createSettingsWindow();
   });
-  
-  w.element.style.resize = 'none'; // Disable resizing
-  w.element.style.overflow = 'hidden'; // Prevent showing resize handles
 
   function createSettingsWindow() {
     const w=createWindow("Wallpaper");
+    w.element.style.resize = 'none'; // Disable resizing
+    w.element.style.overflow = 'hidden'; // Prevent showing resize handles
   
     let desc=document.createElement('div');
     desc.textContent="Change Desktop Color:";


### PR DESCRIPTION
## Summary
- Ensure Task Manager window styling is applied inside `createTaskManagerWindow`
- Apply Wallpaper window styling within `createSettingsWindow`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895fd7139208332a4be90bf9657f9e9